### PR TITLE
Feat/25 이메일회원가입

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,8 @@
     "browser": true,
     "node": true
   },
-  "extends": ["eslint:recommended", "prettier"],
-  "plugins": ["import", "react-hooks", "styled-components-a11y", "prettier"],
+  "extends": ["eslint:recommended"],
+  "plugins": ["import", "react-hooks", "styled-components-a11y"],
   "rules": {
     "jsx-a11y/label-has-associated-control": "off",
     "jsx-a11y/anchor-is-valid": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,8 @@
     "browser": true,
     "node": true
   },
-  "extends": ["eslint:recommended"],
-  "plugins": ["import", "react-hooks", "styled-components-a11y"],
+  "extends": ["eslint:recommended", "prettier"],
+  "plugins": ["import", "react-hooks", "styled-components-a11y", "prettier"],
   "rules": {
     "jsx-a11y/label-has-associated-control": "off",
     "jsx-a11y/anchor-is-valid": "off",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,9 +20,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route path="/test" element={<Test />} />
-          <Route path="/" element={<LoginPage />} />
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignUp />} />
-          <Route path="/home" element={<Home />} />
           <Route path="/group" element={<Group />} />
           <Route path="/kakao/oauth" element={<KakaoCallback />} />
           <Route path="/playlist/:id" element={<PlaylistPage />} />

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,7 +1,10 @@
 import axios from 'axios';
 import Storage from '../utils/localStorage';
 import { Promise } from 'es6-promise';
-import { showAlertWithButton } from '../utils/alertUtils';
+import {
+  showAlertWithButton,
+  showAlertWithoutButton,
+} from '../utils/alertUtils';
 const requestInterceptor = (config) => {
   const token = Storage.getLocalStorage('token');
   if (token) {
@@ -32,8 +35,10 @@ const responseInterceptor = (response) => {
     const outputMessage = config.message || message;
     if (config.onSuccess) {
       onSuccess = config.onSuccess;
+      showAlertWithButton(outputMessage, onSuccess);
+    } else {
+      showAlertWithoutButton(outputMessage);
     }
-    showAlertWithButton(outputMessage, onSuccess);
   }
 
   // request시 전달받은 메시지가 있으면 그것을 로깅하고, 메시지를 초기화

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -3,6 +3,9 @@ import Storage from '../utils/localStorage';
 import { Promise } from 'es6-promise';
 
 const requestInterceptor = (config) => {
+  console.log(config);
+  console.log(`req incep  config: ${config}`);
+  console.log(`req incp config type : ${typeof config}`);
   const token = Storage.getLocalStorage('token');
   if (token) {
     config.headers['Authorization'] = `Bearer ${token}`;

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -42,6 +42,12 @@ const StyledButton = styled.button`
     );
   }
 
+  // disabled 상태
+  &:disabled {
+    background: ${(props) =>
+      props.theme.color.button.disabled}; // 비활성화 상태일 때의 배경 색상
+    cursor: not-allowed; // 커서를 not-allowed로 변경
+  }
   // SearchBar
   ${(props) =>
     props.search &&
@@ -71,6 +77,13 @@ const StyledButton = styled.button`
       height: 2.75rem;
       margin: 1.875rem 0;
       font-weight: 500;
+    `}
+
+    ${(props) =>
+    props.signUp &&
+    css`
+      width: 100%;
+      height: 2.75rem;
     `}
 `;
 

--- a/src/components/modal/AlertModalUI.jsx
+++ b/src/components/modal/AlertModalUI.jsx
@@ -13,8 +13,14 @@ const AlertModalUI = ({
       <AlertWrapper>
         <AlertContainer>
           <AlertMsgWrapper>
-            {message.title && <span>{message.title}</span>}
-            {message.subTitle && <span>{message.subTitle}</span>}
+            {message.title || message.subTitle ? (
+              <>
+                {message.title && <span>{message.title}</span>}
+                {message.subTitle && <span>{message.subTitle}</span>}
+              </>
+            ) : (
+              message
+            )}
           </AlertMsgWrapper>
           {buttonCallback ? (
             <ButtonContainer>
@@ -41,21 +47,24 @@ const AlertWrapper = styled.div`
   height: 100%;
   ${(props) => props.theme.FlexItemCenter};
   color: ${(props) => props.theme.color.text.main};
+  background-color: rgba(0, 0, 0, 0.6);
 `;
 
 const AlertContainer = styled.div`
+  ${(props) => props.theme.FlexItemCenterColumn};
   background-color: ${(props) => props.theme.color.background.main};
   border-radius: 0.5rem;
-  width: 30%;
+  width: 21.25rem;
 `;
 
 const AlertMsgWrapper = styled.div`
   ${(props) => props.theme.FlexColumn};
-  justify-content: flex-start;
+  min-height: 4rem;
   padding: 1rem 1rem;
+  white-space: pre-line;
+  line-height: 1.375rem;
   span {
     letter-spacing: 1px;
-    white-space: pre-line;
   }
   span:nth-child(1) {
     font-size: 1.25rem;
@@ -65,7 +74,6 @@ const AlertMsgWrapper = styled.div`
   span:nth-child(2) {
     font-size: 0.875rem;
     color: ${(props) => props.theme.color.text.sub};
-    margin-bottom: 5px;
   }
 `;
 
@@ -87,6 +95,6 @@ const ProgressBar = styled.div`
 
 const ButtonContainer = styled.div`
   display: flex;
-  justify-content: end;
-  padding: 0 0.5rem 0.5rem 0;
+  align-self: end;
+  padding: 0 0.75rem 0.75rem 0;
 `;

--- a/src/constants/query.js
+++ b/src/constants/query.js
@@ -1,0 +1,11 @@
+const END_POINT = {
+  USER: {
+    SIGN_UP: '/api/users/register',
+  },
+};
+
+const QUERY = {
+  END_POINT,
+};
+
+export default QUERY;

--- a/src/constants/regexPatterns.js
+++ b/src/constants/regexPatterns.js
@@ -1,8 +1,20 @@
-const AUTH = {
-  EMAIL: '^[w-.]+@([w-]+.)+[w-]{2,4}$',
-  PASSWORD: '/^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/', // 숫자, 영문자, 특수문자 1개포함 ,  8~16자
+// 유효성 검사를 위한 정규 표현식 정의
+const patterns = {
+  EMAIL: /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+  // 비밀번호는 적어도 하나의 숫자, 하나의 영문자, 하나의 특수 문자를 포함하고 8-15자 길이여야 함
+  PASSWORD: /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
 };
 
-const REGEX = { AUTH };
+// 인증 관련 패턴을 모아둔 객체
+const AUTH = {
+  EMAIL: patterns.EMAIL,
+  PASSWORD: patterns.PASSWORD,
+};
 
+// 모든 정규 표현식을 하나의 객체로 통합
+const REGEX = {
+  AUTH,
+};
+
+// 다른 곳에서 사용할 수 있도록 정규 표현식 내보내기
 export default REGEX;

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -5,12 +5,12 @@ const AUTH_STRINGS = {
     SIGNUP: '지금 가입하고 \n나만의 플레이리스트를 만들어보세요.',
   },
   SIGN_UP: {
-    EMAIL_VALID_FALSE : '이메일 형식이 옳바르지 않습니다.',
+    EMAIL_VALID_FALSE: '이메일 형식이 옳바르지 않습니다.',
     PASSWORD_VALID: '비밀번호는 영문,숫자,특수문자를 포함하여 8~16자리 입니다.',
     PASSWORD_VALID_TRUE: '사용 가능한 비밀번호 입니다.',
     PASSWORD_VALID_FALSE: '사용 할 수 없는 비밀번호 입니다.',
-    PASSWORD_COMPARE_TRUE: '비밀번호가 같습니다.',
-    PASSWORD_COMPARE_FALSE: '비밀번호가 같지 않습니다. 다시 입력해주세요.',
+    PASSWORD_COMPARE_TRUE: '2차 비밀번호 인증에 성공했습니다.',
+    PASSWORD_COMPARE_FALSE: '2차 비밀번호 인증에 실패했습니다. 다시 확인해주세요.',
   },
 };
 

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -1,8 +1,23 @@
-const AUTH_TITLE = {
-  LOGIN_TITLE: '간편하게 로그인하고 \n나만의 플레이리스트를 만들어보세요.',
-  SIGN_TITLE: '지금 가입하고 \n 나만의 플레이리스트를 만들어보세요.',
+// 인증 관련 문자열 상수를 정의합니다.
+const AUTH_STRINGS = {
+  TITLES: {
+    LOGIN: '간편하게 로그인하고 \n나만의 플레이리스트를 만들어보세요.',
+    SIGNUP: '지금 가입하고 \n나만의 플레이리스트를 만들어보세요.',
+  },
+  SIGN_UP: {
+    EMAIL_VALID_FALSE : '이메일 형식이 옳바르지 않습니다.',
+    PASSWORD_VALID: '비밀번호는 영문,숫자,특수문자를 포함하여 8~16자리 입니다.',
+    PASSWORD_VALID_TRUE: '사용 가능한 비밀번호 입니다.',
+    PASSWORD_VALID_FALSE: '사용 할 수 없는 비밀번호 입니다.',
+    PASSWORD_COMPARE_TRUE: '비밀번호가 같습니다.',
+    PASSWORD_COMPARE_FALSE: '비밀번호가 같지 않습니다. 다시 입력해주세요.',
+  },
 };
 
-const STRINGS = { AUTH_TITLE };
+// 모든 문자열을 STRINGS 객체에 담아서 관리합니다.
+const STRINGS = {
+  AUTH: AUTH_STRINGS,
+};
 
+// 다른 곳에서 사용할 수 있도록 STRINGS 객체 내보내기
 export default STRINGS;

--- a/src/hooks/useCompareString.js
+++ b/src/hooks/useCompareString.js
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+// 문자열 두 데이터의 일치 여부를 확인하는 커스텀 훅
+export const useCompareString = (words, compareWords) => {
+  const [isMatch, setIsMatch] = useState(false);
+
+  useEffect(() => {
+    setIsMatch(words === compareWords && compareWords !== '');
+  }, [words, compareWords]);
+
+  return isMatch;
+};

--- a/src/hooks/useRegexInput.js
+++ b/src/hooks/useRegexInput.js
@@ -1,17 +1,23 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 
-const useRegexInput = (validationMessage, successMessage, regexPattern) => {
+// 입력값 정규식 검증 및 상태 관리를 위한 커스텀 훅
+const useRegexInput = (
+  validationMessage,
+  successMessage,
+  regexPattern,
+  compareValue = null, // 비교 값 (ex> 2차 비밀번호 검증)
+) => {
   const [input, setInput] = useState('');
   const [message, setMessage] = useState('');
-  const [isValid, setIsValid] = useState('');
+  const [isValid, setIsValid] = useState(false);
 
+  // 입력 값 변경 핸들러
   const handleInputChange = useCallback(
     (e) => {
       const { value } = e.target;
       setInput(value);
 
       if (!regexPattern.test(value)) {
-        console.log(regexPattern.test(value));
         setMessage(value === '' ? '' : validationMessage);
         setIsValid(false);
       } else {
@@ -21,17 +27,46 @@ const useRegexInput = (validationMessage, successMessage, regexPattern) => {
     },
     [regexPattern, validationMessage, successMessage],
   );
-  return { input, handleInputChange, message, isValid };
+
+  // 기존 값과 비교 값 검증 핸들러
+  const handleCompareChange = useCallback(
+    (e) => {
+      const { value } = e.target;
+      setInput(value);
+
+      if (value === compareValue && value !== '') {
+        setMessage(successMessage);
+        setIsValid(true);
+      } else if (value === '' && compareValue === '') {
+        setMessage('');
+        setIsValid(false);
+      } else {
+        setMessage(validationMessage);
+        setIsValid(false);
+      }
+    },
+    [validationMessage, successMessage, compareValue],
+  );
+  // 입력값 초기화 핸들러
+  const resetInput = useCallback(() => {
+    setInput(''); // 입력값을 빈 문자열로 설정
+    setMessage(''); // 메시지를 초기화
+    setIsValid(false); // 유효성 상태를 초기화
+  }, []);
+  // 포커스 이벤트 핸들러
+  const handleFocus = useCallback(() => {
+    resetInput();
+  }, [resetInput]);
+
+  return {
+    input,
+    handleInputChange,
+    handleCompareChange,
+    handleFocus,
+    message,
+    isValid,
+    resetInput,
+  };
 };
 
 export default useRegexInput;
-
-export const usePasswordMatch = (password, confirmPassword) => {
-  const [isMatch, setIsMatch] = useState(false);
-
-  useEffect(() => {
-    setIsMatch(password === confirmPassword && confirmPassword !== '');
-  }, [password, confirmPassword]);
-
-  return isMatch;
-};

--- a/src/hooks/useRegexInput.js
+++ b/src/hooks/useRegexInput.js
@@ -1,0 +1,37 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const useRegexInput = (validationMessage, successMessage, regexPattern) => {
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState('');
+  const [isValid, setIsValid] = useState('');
+
+  const handleInputChange = useCallback(
+    (e) => {
+      const { value } = e.target;
+      setInput(value);
+
+      if (!regexPattern.test(value)) {
+        console.log(regexPattern.test(value));
+        setMessage(value === '' ? '' : validationMessage);
+        setIsValid(false);
+      } else {
+        setMessage(successMessage);
+        setIsValid(true);
+      }
+    },
+    [regexPattern, validationMessage, successMessage],
+  );
+  return { input, handleInputChange, message, isValid };
+};
+
+export default useRegexInput;
+
+export const usePasswordMatch = (password, confirmPassword) => {
+  const [isMatch, setIsMatch] = useState(false);
+
+  useEffect(() => {
+    setIsMatch(password === confirmPassword && confirmPassword !== '');
+  }, [password, confirmPassword]);
+
+  return isMatch;
+};

--- a/src/pages/auth/AuthStyles.js
+++ b/src/pages/auth/AuthStyles.js
@@ -9,7 +9,7 @@ const AuthContainer = styled.div`
 const AuthBox = styled.div`
   padding: 1.875rem 1.25rem;
   width: 25rem;
-  border: 2px solid ${(props) => props.theme.color.charcoalGray};
+  border: 2px solid ${(props) => props.theme.color.border.border1};
   text-align: center;
   overflow: hidden;
 `;

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -9,7 +9,7 @@ const LoginPage = () => {
   return (
     <authStyles.AuthContainer>
       <authStyles.AuthBox>
-        <LoginTitle>{STRINGS.AUTH_TITLE.LOGIN_TITLE}</LoginTitle>
+        <LoginTitle>{STRINGS.AUTH.TITLES.LOGIN}</LoginTitle>
         <ButtonWrapper>
           <LoginButton
             kakao
@@ -21,7 +21,7 @@ const LoginPage = () => {
           <LoginButton fullWidth>이메일로 로그인</LoginButton>
         </ButtonWrapper>
         <BottomSection>
-          <a href="#">이메일로 회원가입</a>
+          <a href="/signup">이메일로 회원가입</a>
           <a href="#">비밀번호 찾기</a>
         </BottomSection>
       </authStyles.AuthBox>

--- a/src/pages/auth/SignUp.jsx
+++ b/src/pages/auth/SignUp.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 import { LoginButton } from '../../components/common/Button';
@@ -7,38 +7,85 @@ import authStyles from './AuthStyles';
 import STRINGS from '../../constants/strings';
 import PLACEHOLDERS from '../../constants/placeholders';
 import Input from '../../components/common/Input';
-
+import useRegexInput from '../../hooks/useRegexInput';
+import REGEX from '../../constants/regexPatterns';
+import STRING from '../../constants/strings';
 const SignUp = () => {
+  const usePasswordMatch = (password, confirmPassword) => {
+    const [isMatch, setIsMatch] = useState(false);
+
+    useEffect(() => {
+      setIsMatch(password === confirmPassword && confirmPassword !== '');
+    }, [password, confirmPassword]);
+
+    return isMatch;
+  };
+
+  // const pwRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/;
+  const pwRegex = REGEX.AUTH.PASSWORD;
+  const emailRegex = REGEX.AUTH.EMAIL;
+
+  const {
+    input: inputEmail,
+    handleInputChange: handleEmailChange,
+    message: emailMessage,
+    isValid: isEmailValid,
+  } = useRegexInput(STRING.AUTH.SIGN_UP.EMAIL_VALID_FALSE, '', emailRegex);
+  const {
+    input: inputPw,
+    handleInputChange: handlePwChange,
+    message: pwMessage,
+    isValid: isPwValid,
+  } = useRegexInput(
+    STRING.AUTH.SIGN_UP.PASSWORD_VALID_FALSE,
+    STRING.AUTH.SIGN_UP.PASSWORD_VALID_TRUE,
+    pwRegex,
+  );
+  const {
+    input: inputCheckPw,
+    handleInputChange: handleCheckPwChange,
+    message: checkPwMessage,
+  } = useRegexInput(
+    '비밀번호가 같지 않습니다. 다시 입력해주세요.',
+    '비밀번호가 같습니다.',
+    pwRegex,
+  );
+  const isPasswordMatch = usePasswordMatch(inputPw, inputCheckPw);
+
   return (
     <authStyles.AuthContainer>
       <authStyles.AuthBox>
-        <SignTitle>{STRINGS.AUTH_TITLE.SIGN_TITLE}</SignTitle>
+        <SignTitle>{STRINGS.AUTH.TITLES.SIGNUP}</SignTitle>
         <InputContainer>
           <StyleInput
-            type="text"
+            type="email"
+            value={inputEmail}
+            onChange={handleEmailChange}
             placeholder={PLACEHOLDERS.ENTER_INPUT('이메일을 ')}
-            marginTop="55px"
+            autoComplete="off"
           ></StyleInput>
+          <AlertSpan isMatch={isEmailValid}>{emailMessage}</AlertSpan>
           <StyleInput
-            type="text"
+            type="password"
             placeholder={PLACEHOLDERS.ENTER_INPUT('비밀번호를 ')}
-            marginTop="55px"
+            value={inputPw}
+            onChange={handlePwChange}
+            autoComplete="off"
+            maxLength="16"
           ></StyleInput>
+          {!inputPw && (
+            <AlertSpan>{STRING.AUTH.SIGN_UP.PASSWORD_VALID}</AlertSpan>
+          )}
+          <AlertSpan isMatch={isPwValid}>{pwMessage}</AlertSpan>
           <StyleInput
-            type="text"
+            type="password"
             placeholder={PLACEHOLDERS.ENTER_INPUT('비밀번호를 재')}
-            marginTop="55px"
+            value={inputCheckPw}
+            onChange={handleCheckPwChange}
+            autoComplete="off"
+            maxLength="16"
           ></StyleInput>
-          <StyleInput
-            type="text"
-            placeholder={PLACEHOLDERS.ENTER_INPUT('이름을 ')}
-            marginTop="55px"
-          ></StyleInput>
-          <StyleInput
-            type="text"
-            placeholder={PLACEHOLDERS.ENTER_INPUT('닉네임을 ')}
-            marginTop="55px"
-          ></StyleInput>
+          <AlertSpan isMatch={isPasswordMatch}>{checkPwMessage}</AlertSpan>
         </InputContainer>
         <ButtonWrapper>
           <LoginButton>이메일로 로그인</LoginButton>
@@ -68,10 +115,24 @@ const InputContainer = styled.div`
 
 const StyleInput = styled(Input).attrs({
   padding: '1.5rem 0 1.25rem 0',
-  border: `1px solid ${(props) => props.theme.color.charcoalGray}`,
+  border: `1px solid ${(props) => props.theme.color.border.border1}`,
+  margin: ` 1rem 0 0 0`,
 })`
   border-width: 0 0 1px;
   outline: none;
+`;
+
+const AlertSpan = styled.span`
+  align-self: flex-start;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  font-family: 'scdream4';
+  font-weight: 600;
+
+  color: ${(props) =>
+    props.isMatch
+      ? props.theme.color.text.success
+      : props.theme.color.text.alert};
 `;
 
 const ButtonWrapper = styled.div`

--- a/src/pages/auth/SignUp.jsx
+++ b/src/pages/auth/SignUp.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
-import { LoginButton } from '../../components/common/Button';
+import Button from '../../components/common/Button';
 
 import authStyles from './AuthStyles';
 import STRINGS from '../../constants/strings';
@@ -10,6 +10,10 @@ import Input from '../../components/common/Input';
 import useRegexInput from '../../hooks/useRegexInput';
 import REGEX from '../../constants/regexPatterns';
 import STRING from '../../constants/strings';
+import QUERY from '../../constants/query';
+import { api } from '../../api/axios';
+import { sassTrue } from 'sass';
+
 const SignUp = () => {
   const usePasswordMatch = (password, confirmPassword) => {
     const [isMatch, setIsMatch] = useState(false);
@@ -21,16 +25,31 @@ const SignUp = () => {
     return isMatch;
   };
 
+  const handleSignUp = async () => {
+    const userInfo = {
+      email: inputEmail,
+      password: inputPw,
+    };
+    try {
+      const res = await api.post(QUERY.END_POINT.USER.SIGN_UP, userInfo);
+      console.log(res);
+    } catch (err) {
+      console.log(err);
+    }
+  };
   // const pwRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/;
   const pwRegex = REGEX.AUTH.PASSWORD;
   const emailRegex = REGEX.AUTH.EMAIL;
 
+  // 이메일 검증 -> 커스텀 훅 사용
   const {
     input: inputEmail,
     handleInputChange: handleEmailChange,
     message: emailMessage,
     isValid: isEmailValid,
   } = useRegexInput(STRING.AUTH.SIGN_UP.EMAIL_VALID_FALSE, '', emailRegex);
+
+  // 비밀번호 검증 -> 커스텀 훅 사용
   const {
     input: inputPw,
     handleInputChange: handlePwChange,
@@ -41,16 +60,23 @@ const SignUp = () => {
     STRING.AUTH.SIGN_UP.PASSWORD_VALID_TRUE,
     pwRegex,
   );
+
+  // 2차 비밀번호 검증 -> 커스텀 훅 사용
   const {
     input: inputCheckPw,
     handleInputChange: handleCheckPwChange,
     message: checkPwMessage,
   } = useRegexInput(
-    '비밀번호가 같지 않습니다. 다시 입력해주세요.',
-    '비밀번호가 같습니다.',
+    STRINGS.AUTH.SIGN_UP.PASSWORD_COMPARE_FALSE,
+    STRINGS.AUTH.SIGN_UP.PASSWORD_COMPARE_TRUE,
     pwRegex,
   );
+
+  // 비밀번호, 2차 비밀번호 비교
   const isPasswordMatch = usePasswordMatch(inputPw, inputCheckPw);
+
+  // 이메일, 비밀번호, 2차 비밀번호 모두 유효한지 여부
+  const isFormValid = isEmailValid && isPwValid && isPasswordMatch;
 
   return (
     <authStyles.AuthContainer>
@@ -85,10 +111,14 @@ const SignUp = () => {
             autoComplete="off"
             maxLength="16"
           ></StyleInput>
-          <AlertSpan isMatch={isPasswordMatch}>{checkPwMessage}</AlertSpan>
+          <AlertSpan isMatch={isPasswordMatch && isPwValid}>
+            {checkPwMessage}
+          </AlertSpan>
         </InputContainer>
         <ButtonWrapper>
-          <LoginButton>이메일로 로그인</LoginButton>
+          <Button signUp onClick={handleSignUp} disabled={!isFormValid}>
+            회원가입
+          </Button>
         </ButtonWrapper>
         <BottomSection>
           <a href="#">이메일로 회원가입</a>
@@ -138,6 +168,7 @@ const AlertSpan = styled.span`
 const ButtonWrapper = styled.div`
   ${(props) => props.theme.FlexItemCenterColumn}
   margin: 2.75rem 0;
+  padding: 0 0.875rem;
   gap: 0.625rem; // 상하좌우 여백
 `;
 

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -11,7 +11,7 @@ import modalReducer from './modalSlice';
 import playerReducer from './playerSlice';
 import toastReducer from './toastSlice';
 
-import testReducer from './ttestSlice';
+// import testReducer from './ttestSlice';
 export default configureStore({
   reducer: {
     auth: authReducer,
@@ -20,7 +20,7 @@ export default configureStore({
     modal: modalReducer,
     player: playerReducer,
     toast: toastReducer,
-    ttest: testReducer,
+    // ttest: testReducer,
   },
   // middleware 추가 코드이다. Redux에서는 action을 전달할 때 직렬화된 string형태의 데이터를 보내야한다.
   // Player.jsx 컴포넌트에서 전달하는 seekTo 함수는 직렬화된 데이터가 아니기 때문에 에러가 발생

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -42,6 +42,7 @@ const themeColors = {
     gradientEnd: colors.lightBlue,
     hoverGradientStart: 'rgba(155, 45, 239, 1)',
     hoverGradientEnd: 'rgba(45, 206, 239, 1)',
+    disabled: colors.darkGray,
   },
   border: {
     border1: colors.charcoalGray,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -8,58 +8,51 @@ import {
 } from './flexStyles';
 import { CommonMedia } from './commonMediaStyles';
 
-/**
- *  색상 설정
- */
-const background = {
-  default: '#161a1a', // 유지됨: 전체 페이지의 기본 배경으로 'dark' 색상을 유지
-  main: '#333333', // 수정됨: 모달 창 배경을 'charcoalGray'에서 더 어둡게 변경하여 전체 배경과 구분
-  footer: '#424346',
-  overlay: 'rgba(0, 0, 0, 0.6)', // 추가됨: 모달 오버레이 배경 색상을 불투명도를 증가시켜 추가
-};
-
-const text = {
-  main: '#FAFAFA', // 유지됨: 기본 텍스트로 'offWhite' 색상을 유지
-  sub: '#B0B0B0', // 수정됨: 작은 텍스트에 사용되는 'softGray' 색상을 밝게 변경하여 가독성 향상
-  sub1: '#D3D3D3', // sub와 대비
-  alert: '#FF3E29', // 유지됨: 경고 및 주의 텍스트에 사용되는 'red' 색상을 유지
-};
-
-const button = {
-  gradientStart: '#9b2def', // 유지됨: 버튼 그라디언트 시작 색상으로 'lightPurple' 색상을 유지
-  gradientEnd: '#2dceef', // 유지됨: 버튼 그라디언트 끝 색상으로 'lightBlue' 색상을 유지
-  hoverGradientStart: 'rgba(155, 45, 239, 1)', // 추가됨: 버튼 호버 시 그라디언트 시작 색상을 명시적으로 추가
-  hoverGradientEnd: 'rgba(45, 206, 239, 1)', // 추가됨: 버튼 호버 시 그라디언트 끝 색상을 명시적으로 추가
-};
-
-const border = {
-  border1: '#333333', // input
-  border2: '#808080', // input2
-  border3: '#99999f', // input Focus
-};
-
-const icon = {
-  main: '#FAFAFA',
-  red: '#FF3E29',
-};
-
-const color = {
-  background,
-  text,
-  button,
-  border,
-  icon,
-  charcoalGray: '#3a3a3d', // 플레이 프로그레스바, 선택된 그룹 강조
-  dark: '#161a1a', // 헤더, 배경
-  darkGray: '#424346', // footer, 비활성 버튼
-  lightGray: '#d5d5d5', // view all 버튼 등등 ...
-  softGray: '#B0B0B0', // 작은 텍스트, 아티스트, 제목, 좋아요 수 ...
-  lightBlue: '#2dceef', // 버튼 그라데이션_2, 경계선, 구분선
+const colors = {
+  dark: '#161a1a',
+  charcoalGray: '#333333',
+  darkGray: '#424346',
+  softGray: '#B0B0B0',
+  lightGray: '#d5d5d5',
   white: '#FFFFFF',
-  lightPurple: '#9b2def', // 버튼 그라데이션_1
-  offWhite: '#FAFAFA', // 주요 텍스트
-  red: '#FF3E29', // 경고
-  footerGray: '#808080', // 푸터 작은 텍스트, 사이드바 테두리
+  offWhite: '#FAFAFA',
+  red: '#FF3E29',
+  lightBlue: '#2dceef',
+  lightPurple: '#9b2def',
+  footerGray: '#808080',
+};
+
+// 컨텍스트에 따른 색상 구조화
+const themeColors = {
+  background: {
+    default: colors.dark,
+    main: colors.charcoalGray,
+    footer: colors.darkGray,
+    overlay: 'rgba(0, 0, 0, 0.6)',
+  },
+  text: {
+    main: colors.offWhite,
+    sub: colors.softGray,
+    sub1: '#D3D3D3',
+    alert: colors.red,
+    success: colors.lightBlue,
+  },
+  button: {
+    gradientStart: colors.lightPurple,
+    gradientEnd: colors.lightBlue,
+    hoverGradientStart: 'rgba(155, 45, 239, 1)',
+    hoverGradientEnd: 'rgba(45, 206, 239, 1)',
+  },
+  border: {
+    border1: colors.charcoalGray,
+    border2: colors.footerGray,
+    border3: '#99999f',
+  },
+  icon: {
+    main: colors.offWhite,
+    red: colors.red,
+  },
+  // 추가적인 색상 관련 구조화는 필요에 따라 진행
 };
 
 /**
@@ -87,7 +80,7 @@ const fontWeight = {
 };
 
 const theme = {
-  color,
+  // color,
   FlexItemCenter,
   FlexCenter,
   FlexColumn,
@@ -98,6 +91,7 @@ const theme = {
   headerHeight,
   CommonMedia,
   fontWeight,
+  color: themeColors,
 };
 
 export default theme;


### PR DESCRIPTION
## 개요
- 회원가입 페이지 UI 구성
- 정규표현식을 사용하여 검증하는 커스텀 훅 생성
- 커스텀 axios 컴포넌트 수정
## 작업사항
1. User 테이블의 이메일, 비밀번호 컬럼에 알맞는 데이터를 전송하기 위해서 정규 표현식을 사용하여 옳바른 형식의 데이터만 전달되기 위해서 입력값을 검증하는 커스텀 훅 useRegexInput을 추가
2. axios 컴포넌트를 수정하여 클라이언트가 응답 성공 메시지를 포함하여 서버로 전달하도록 하고, 결과 메시지를 Alert을 통해 렌더링 하도록 변경.
## 테스트
1. useRegexInput 검증 결과 렌더링
- 잘못된 비밀번호
<img width="351" alt="pw_fail" src="https://github.com/YAMPLI/yampli_client/assets/51108221/186427de-1395-4fad-acad-a6b713ea4210">

- 잘못된 2차 비밀번호 
<img width="361" alt="2차_fail" src="https://github.com/YAMPLI/yampli_client/assets/51108221/49c5ebf2-8109-497d-b8c7-4ee05c848b98">

- 옳바른 데이터
<img width="349" alt="email_pw_pwcheck_ok" src="https://github.com/YAMPLI/yampli_client/assets/51108221/e7fd7e0e-5e2d-4225-9598-71ffbf09e4c3">

close #25 